### PR TITLE
Adds binary to use with command line

### DIFF
--- a/bin/validate
+++ b/bin/validate
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+const validator = require('../index.js');
+
+console.log(validator(process.argv[2]));

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "build": "npm run build-normal && npm run build-min",
     "test": "mocha"
   },
+  "bin": {
+    "validate-uc-number": "bin/validate"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mrpatiwi/uc-numero-alumno.git"


### PR DESCRIPTION
Adds binary file to use validator from command line.

### Example
```shell
$ validate-uc-number 10637419
=> true
```

### Improvements
Maybe we should print a more user-friendly message, for instance:

```shell
$ validate-uc-number 10637419
=> 10637419 is a valid UC student number.
```